### PR TITLE
Expose preview scale type (FIT_CENTER / FILL_CENTER) configuration (K…

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -220,6 +220,7 @@ val cameraState by rememberCameraKState(
 
         // Visual settings
         aspectRatio = AspectRatio.RATIO_16_9,   // 4:3, 16:9, 9:16, 1:1
+        previewScaleType = PreviewScaleType.FIT_CENTER, // FIT_CENTER or FILL_CENTER
         targetResolution = 1920 to 1080,        // Optional specific resolution
 
         // Flash control
@@ -256,6 +257,7 @@ val cameraState by rememberCameraKState(
 |----------|------|---------|-------------|
 | `cameraLens` | `CameraLens` | `BACK` | Front or back camera |
 | `aspectRatio` | `AspectRatio` | `RATIO_16_9` | 4:3, 16:9, 9:16, or 1:1 |
+| `previewScaleType` | `PreviewScaleType` | `FIT_CENTER` | FIT_CENTER or FILL_CENTER |
 | `targetResolution` | `Pair<Int, Int>?` | `null` | Specific width x height |
 | `flashMode` | `FlashMode` | `OFF` | ON, OFF, or AUTO |
 | `torchMode` | `TorchMode` | `OFF` | ON, OFF, or AUTO |
@@ -315,6 +317,17 @@ AspectRatio.RATIO_16_9  // Widescreen (most common)
 AspectRatio.RATIO_9_16  // Vertical stories (Instagram, TikTok)
 AspectRatio.RATIO_1_1   // Square (Instagram feed)
 ```
+
+### Preview Scale Type
+
+How the camera preview is scaled within its container view when the aspect ratios differ:
+
+```kotlin
+PreviewScaleType.FIT_CENTER   // Fit the whole frame, letterboxing overflow (default)
+PreviewScaleType.FILL_CENTER  // Fill the container, cropping overflow
+```
+
+On Android these map to `PreviewView.ScaleType.FIT_CENTER` / `FILL_CENTER`; on iOS they map to `AVLayerVideoGravityResizeAspect` / `AVLayerVideoGravityResizeAspectFill`.
 
 ### Image Formats
 

--- a/cameraK/src/androidMain/kotlin/com/kashif/cameraK/builder/AndroidCameraControllerBuilder.kt
+++ b/cameraK/src/androidMain/kotlin/com/kashif/cameraK/builder/AndroidCameraControllerBuilder.kt
@@ -9,6 +9,7 @@ import com.kashif.cameraK.enums.CameraLens
 import com.kashif.cameraK.enums.Directory
 import com.kashif.cameraK.enums.FlashMode
 import com.kashif.cameraK.enums.ImageFormat
+import com.kashif.cameraK.enums.PreviewScaleType
 import com.kashif.cameraK.enums.QualityPrioritization
 import com.kashif.cameraK.enums.TorchMode
 import com.kashif.cameraK.utils.InvalidConfigurationException
@@ -30,6 +31,7 @@ class AndroidCameraControllerBuilder(private val context: Context, private val l
     private var qualityPriority: QualityPrioritization = QualityPrioritization.NONE
     private var cameraDeviceType: CameraDeviceType = CameraDeviceType.DEFAULT
     private var aspectRatio: AspectRatio = AspectRatio.RATIO_4_3
+    private var previewScaleType: PreviewScaleType = PreviewScaleType.FIT_CENTER
     private var targetResolution: Pair<Int, Int>? = null
     private var mirrorFrontCamera: Boolean = false
 
@@ -78,6 +80,11 @@ class AndroidCameraControllerBuilder(private val context: Context, private val l
         return this
     }
 
+    override fun setPreviewScaleType(previewScaleType: PreviewScaleType): CameraControllerBuilder {
+        this.previewScaleType = previewScaleType
+        return this
+    }
+
     override fun setResolution(width: Int, height: Int): CameraControllerBuilder {
         this.targetResolution = width to height
         return this
@@ -108,6 +115,7 @@ class AndroidCameraControllerBuilder(private val context: Context, private val l
             qualityPriority = qualityPriority,
             cameraDeviceType = cameraDeviceType,
             aspectRatio = aspectRatio,
+            previewScaleType = previewScaleType,
             targetResolution = targetResolution,
             mirrorFrontCamera = mirrorFrontCamera,
         )

--- a/cameraK/src/androidMain/kotlin/com/kashif/cameraK/compose/CameraPreviewView.android.kt
+++ b/cameraK/src/androidMain/kotlin/com/kashif/cameraK/compose/CameraPreviewView.android.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import com.kashif.cameraK.controller.CameraController
 import com.kashif.cameraK.enums.DeviceOrientation
+import com.kashif.cameraK.enums.PreviewScaleType
 import com.kashif.cameraK.enums.previewAspectRatio
 
 @Composable
@@ -25,9 +26,13 @@ actual fun CameraPreviewView(
 ) {
     val context = LocalContext.current
     // FIT_CENTER shows the whole frame (letterboxed) instead of cropping it to fill the view,
-    // so the preview matches the captured field of view.
+    // so the preview matches the captured field of view. FILL_CENTER crops the frame to fill.
+    val previewScaleType = when (controller.getPreviewScaleType()) {
+        PreviewScaleType.FIT_CENTER -> PreviewView.ScaleType.FIT_CENTER
+        PreviewScaleType.FILL_CENTER -> PreviewView.ScaleType.FILL_CENTER
+    }
     val previewView = remember {
-        PreviewView(context).apply { scaleType = PreviewView.ScaleType.FIT_CENTER }
+        PreviewView(context).apply { scaleType = previewScaleType }
     }
 
     DisposableEffect(controller, previewView) {

--- a/cameraK/src/androidMain/kotlin/com/kashif/cameraK/compose/RememberCameraKState.android.kt
+++ b/cameraK/src/androidMain/kotlin/com/kashif/cameraK/compose/RememberCameraKState.android.kt
@@ -44,6 +44,7 @@ actual fun rememberCameraKState(
                                 setQualityPrioritization(config.qualityPrioritization)
                                 setPreferredCameraDeviceType(config.cameraDeviceType)
                                 setAspectRatio(config.aspectRatio)
+                                setPreviewScaleType(config.previewScaleType)
                                 setDirectory(config.directory)
                                 setMirrorFrontCamera(config.mirrorFrontCamera)
                                 config.targetResolution?.let { (width, height) ->

--- a/cameraK/src/androidMain/kotlin/com/kashif/cameraK/controller/CameraController.android.kt
+++ b/cameraK/src/androidMain/kotlin/com/kashif/cameraK/controller/CameraController.android.kt
@@ -46,6 +46,7 @@ import com.kashif.cameraK.enums.DeviceOrientation
 import com.kashif.cameraK.enums.Directory
 import com.kashif.cameraK.enums.FlashMode
 import com.kashif.cameraK.enums.ImageFormat
+import com.kashif.cameraK.enums.PreviewScaleType
 import com.kashif.cameraK.enums.QualityPrioritization
 import com.kashif.cameraK.enums.TorchMode
 import com.kashif.cameraK.result.ImageCaptureResult
@@ -82,6 +83,7 @@ actual class CameraController(
     internal var directory: Directory,
     internal var cameraDeviceType: CameraDeviceType,
     internal var aspectRatio: AspectRatio,
+    internal var previewScaleType: PreviewScaleType = PreviewScaleType.FIT_CENTER,
     internal var targetResolution: Pair<Int, Int>? = null,
     internal var mirrorFrontCamera: Boolean = false,
 ) {
@@ -629,6 +631,8 @@ actual class CameraController(
     actual fun getImageFormat(): ImageFormat = imageFormat
 
     actual fun getAspectRatio(): AspectRatio = aspectRatio
+
+    actual fun getPreviewScaleType(): PreviewScaleType = previewScaleType
 
     actual fun getQualityPrioritization(): QualityPrioritization = qualityPriority
 

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/builder/IOSCameraControllerBuilder.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/builder/IOSCameraControllerBuilder.kt
@@ -7,6 +7,7 @@ import com.kashif.cameraK.enums.CameraLens
 import com.kashif.cameraK.enums.Directory
 import com.kashif.cameraK.enums.FlashMode
 import com.kashif.cameraK.enums.ImageFormat
+import com.kashif.cameraK.enums.PreviewScaleType
 import com.kashif.cameraK.enums.QualityPrioritization
 import com.kashif.cameraK.enums.TorchMode
 import com.kashif.cameraK.utils.InvalidConfigurationException
@@ -24,6 +25,7 @@ class IOSCameraControllerBuilder : CameraControllerBuilder {
     private var qualityPriority: QualityPrioritization = QualityPrioritization.NONE
     private var cameraDeviceType: CameraDeviceType = CameraDeviceType.DEFAULT
     private var aspectRatio: AspectRatio = AspectRatio.RATIO_4_3
+    private var previewScaleType: PreviewScaleType = PreviewScaleType.FIT_CENTER
     private var targetResolution: Pair<Int, Int>? = null
     private var mirrorFrontCamera: Boolean = false
 
@@ -59,6 +61,11 @@ class IOSCameraControllerBuilder : CameraControllerBuilder {
 
     override fun setAspectRatio(aspectRatio: AspectRatio): CameraControllerBuilder {
         this.aspectRatio = aspectRatio
+        return this
+    }
+
+    override fun setPreviewScaleType(previewScaleType: PreviewScaleType): CameraControllerBuilder {
+        this.previewScaleType = previewScaleType
         return this
     }
 
@@ -103,6 +110,7 @@ class IOSCameraControllerBuilder : CameraControllerBuilder {
             qualityPriority = qualityPriority,
             cameraDeviceType = cameraDeviceType,
             aspectRatio = aspectRatio,
+            previewScaleType = previewScaleType,
             targetResolution = targetResolution,
             mirrorFrontCamera = mirrorFrontCamera,
         )

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/compose/RememberCameraKState.apple.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/compose/RememberCameraKState.apple.kt
@@ -36,6 +36,7 @@ actual fun rememberCameraKState(
                             setQualityPrioritization(config.qualityPrioritization)
                             setPreferredCameraDeviceType(config.cameraDeviceType)
                             setAspectRatio(config.aspectRatio)
+                            setPreviewScaleType(config.previewScaleType)
                             setDirectory(config.directory)
                             setMirrorFrontCamera(config.mirrorFrontCamera)
                             config.targetResolution?.let { (width, height) ->

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CameraController.apple.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CameraController.apple.kt
@@ -8,6 +8,7 @@ import com.kashif.cameraK.enums.DeviceOrientation
 import com.kashif.cameraK.enums.Directory
 import com.kashif.cameraK.enums.FlashMode
 import com.kashif.cameraK.enums.ImageFormat
+import com.kashif.cameraK.enums.PreviewScaleType
 import com.kashif.cameraK.enums.QualityPrioritization
 import com.kashif.cameraK.enums.TorchMode
 import com.kashif.cameraK.result.ImageCaptureResult
@@ -73,6 +74,7 @@ actual class CameraController(
     internal var directory: Directory,
     internal var cameraDeviceType: CameraDeviceType,
     internal var aspectRatio: AspectRatio,
+    internal var previewScaleType: PreviewScaleType = PreviewScaleType.FIT_CENTER,
     internal var targetResolution: Pair<Int, Int>? = null,
     internal var mirrorFrontCamera: Boolean = false,
 ) : UIViewController(null, null) {
@@ -81,6 +83,7 @@ actual class CameraController(
         qualityPrioritization = qualityPriority,
         initialCameraLens = cameraLens,
         aspectRatio = aspectRatio,
+        previewScaleType = previewScaleType,
         targetResolution = targetResolution,
         mirrorFrontCamera = mirrorFrontCamera,
     )
@@ -449,6 +452,8 @@ actual class CameraController(
     actual fun getImageFormat(): ImageFormat = imageFormat
 
     actual fun getAspectRatio(): AspectRatio = aspectRatio
+
+    actual fun getPreviewScaleType(): PreviewScaleType = previewScaleType
 
     actual fun getQualityPrioritization(): QualityPrioritization = qualityPriority
 

--- a/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CustomCameraController.kt
+++ b/cameraK/src/appleMain/kotlin/com/kashif/cameraK/controller/CustomCameraController.kt
@@ -4,6 +4,7 @@ import com.kashif.cameraK.capabilities.LensInfo
 import com.kashif.cameraK.enums.AspectRatio
 import com.kashif.cameraK.enums.CameraDeviceType
 import com.kashif.cameraK.enums.CameraLens
+import com.kashif.cameraK.enums.PreviewScaleType
 import com.kashif.cameraK.enums.QualityPrioritization
 import com.kashif.cameraK.utils.CameraKLogger
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -36,6 +37,7 @@ class CustomCameraController(
     val qualityPrioritization: QualityPrioritization,
     private var initialCameraLens: CameraLens = CameraLens.BACK,
     private val aspectRatio: AspectRatio = AspectRatio.RATIO_4_3,
+    private val previewScaleType: PreviewScaleType = PreviewScaleType.FIT_CENTER,
     private val targetResolution: Pair<Int, Int>? = null,
     private val mirrorFrontCamera: Boolean = false,
 ) : NSObject(),
@@ -384,9 +386,12 @@ class CustomCameraController(
         val session = captureSession ?: return
 
         val newPreviewLayer = AVCaptureVideoPreviewLayer(session = session).apply {
-            // ResizeAspect (letterbox) so the preview shows the exact frame that gets captured — WYSIWYG (#119).
-            // ResizeAspectFill would crop the preview to fill the view, mismatching the full-frame captured photo.
-            videoGravity = AVLayerVideoGravityResizeAspect
+            // FIT_CENTER (ResizeAspect) letterboxes so the preview shows the exact captured frame —
+            // WYSIWYG (#119). FILL_CENTER (ResizeAspectFill) crops to fill the view instead.
+            videoGravity = when (previewScaleType) {
+                PreviewScaleType.FIT_CENTER -> AVLayerVideoGravityResizeAspect
+                PreviewScaleType.FILL_CENTER -> AVLayerVideoGravityResizeAspectFill
+            }
             setFrame(view.bounds)
             connection?.videoOrientation = currentVideoOrientation()
         }

--- a/cameraK/src/commonMain/kotlin/com/kashif/cameraK/builder/CameraControllerBuilder.kt
+++ b/cameraK/src/commonMain/kotlin/com/kashif/cameraK/builder/CameraControllerBuilder.kt
@@ -7,6 +7,7 @@ import com.kashif.cameraK.enums.CameraLens
 import com.kashif.cameraK.enums.Directory
 import com.kashif.cameraK.enums.FlashMode
 import com.kashif.cameraK.enums.ImageFormat
+import com.kashif.cameraK.enums.PreviewScaleType
 import com.kashif.cameraK.enums.QualityPrioritization
 import com.kashif.cameraK.enums.TorchMode
 
@@ -53,6 +54,12 @@ interface CameraControllerBuilder {
      * Supported values map to platform defaults (16:9, 4:3). 9:16 uses 16:9 with rotation; 1:1 falls back to closest available.
      */
     fun setAspectRatio(aspectRatio: AspectRatio): CameraControllerBuilder
+
+    /**
+     * Sets how the preview is scaled within its container view.
+     * Defaults to [PreviewScaleType.FIT_CENTER].
+     */
+    fun setPreviewScaleType(previewScaleType: PreviewScaleType): CameraControllerBuilder
 
     /**
      * Sets a target capture resolution (width x height) for preview/capture when the platform supports it.

--- a/cameraK/src/commonMain/kotlin/com/kashif/cameraK/controller/CameraController.kt
+++ b/cameraK/src/commonMain/kotlin/com/kashif/cameraK/controller/CameraController.kt
@@ -7,6 +7,7 @@ import com.kashif.cameraK.enums.CameraLens
 import com.kashif.cameraK.enums.DeviceOrientation
 import com.kashif.cameraK.enums.FlashMode
 import com.kashif.cameraK.enums.ImageFormat
+import com.kashif.cameraK.enums.PreviewScaleType
 import com.kashif.cameraK.enums.QualityPrioritization
 import com.kashif.cameraK.enums.TorchMode
 import com.kashif.cameraK.result.ImageCaptureResult
@@ -99,6 +100,13 @@ expect class CameraController {
      * @return The configured [AspectRatio]
      */
     fun getAspectRatio(): AspectRatio
+
+    /**
+     * Gets how the preview is scaled within its container view.
+     *
+     * @return The configured [PreviewScaleType]
+     */
+    fun getPreviewScaleType(): PreviewScaleType
 
     /**
      * Gets the current quality prioritization setting.

--- a/cameraK/src/commonMain/kotlin/com/kashif/cameraK/enums/PreviewScaleType.kt
+++ b/cameraK/src/commonMain/kotlin/com/kashif/cameraK/enums/PreviewScaleType.kt
@@ -1,0 +1,14 @@
+package com.kashif.cameraK.enums
+
+/**
+ * How the camera preview is scaled within its container view.
+ *
+ * - [FIT_CENTER]: scale the whole frame to fit, letterboxing if the aspect ratios differ.
+ *   Maps to `PreviewView.ScaleType.FIT_CENTER` on Android and `AVLayerVideoGravityResizeAspect` on iOS.
+ * - [FILL_CENTER]: scale the frame to fill the container, cropping overflow if the aspect ratios differ.
+ *   Maps to `PreviewView.ScaleType.FILL_CENTER` on Android and `AVLayerVideoGravityResizeAspectFill` on iOS.
+ */
+enum class PreviewScaleType {
+    FIT_CENTER,
+    FILL_CENTER,
+}

--- a/cameraK/src/commonMain/kotlin/com/kashif/cameraK/state/CameraKState.kt
+++ b/cameraK/src/commonMain/kotlin/com/kashif/cameraK/state/CameraKState.kt
@@ -8,6 +8,7 @@ import com.kashif.cameraK.enums.CameraLens
 import com.kashif.cameraK.enums.Directory
 import com.kashif.cameraK.enums.FlashMode
 import com.kashif.cameraK.enums.ImageFormat
+import com.kashif.cameraK.enums.PreviewScaleType
 import com.kashif.cameraK.enums.QualityPrioritization
 import com.kashif.cameraK.enums.TorchMode
 import com.kashif.cameraK.result.ImageCaptureResult
@@ -264,6 +265,7 @@ data class CameraConfiguration(
     val qualityPrioritization: QualityPrioritization = QualityPrioritization.BALANCED,
     val cameraDeviceType: CameraDeviceType = CameraDeviceType.DEFAULT,
     val aspectRatio: AspectRatio = AspectRatio.RATIO_16_9,
+    val previewScaleType: PreviewScaleType = PreviewScaleType.FIT_CENTER,
     val targetResolution: Pair<Int, Int>? = null,
     val directory: Directory = Directory.PICTURES,
     val mirrorFrontCamera: Boolean = false,

--- a/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/compose/RememberCameraKState.desktop.kt
+++ b/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/compose/RememberCameraKState.desktop.kt
@@ -32,6 +32,7 @@ actual fun rememberCameraKState(
                             setImageFormat(config.imageFormat)
                             setDirectory(config.directory)
                             setAspectRatio(config.aspectRatio)
+                            setPreviewScaleType(config.previewScaleType)
                             setMirrorFrontCamera(config.mirrorFrontCamera)
                             config.targetResolution?.let { (width, height) ->
                                 setResolution(width, height)

--- a/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/controller/CameraController.desktop.kt
+++ b/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/controller/CameraController.desktop.kt
@@ -9,6 +9,7 @@ import com.kashif.cameraK.enums.DeviceOrientation
 import com.kashif.cameraK.enums.Directory
 import com.kashif.cameraK.enums.FlashMode
 import com.kashif.cameraK.enums.ImageFormat
+import com.kashif.cameraK.enums.PreviewScaleType
 import com.kashif.cameraK.enums.QualityPrioritization
 import com.kashif.cameraK.enums.TorchMode
 import com.kashif.cameraK.result.ImageCaptureResult
@@ -45,6 +46,7 @@ actual class CameraController(
     private val customGrabber: FrameGrabber? = null,
     private val targetResolution: Pair<Int, Int>? = null,
     private val aspectRatio: AspectRatio = AspectRatio.RATIO_16_9,
+    private val previewScaleType: PreviewScaleType = PreviewScaleType.FIT_CENTER,
 ) {
     private var cameraGrabber: CameraGrabber? = null
     private val _frameFlow = MutableSharedFlow<BufferedImage>(
@@ -162,6 +164,8 @@ actual class CameraController(
     // Reports the configured ratio so multiplatform UI can size consistently. The desktop capture
     // path itself renders the webcam's native frame (no ViewPort crop), so it doesn't enforce it.
     actual fun getAspectRatio(): AspectRatio = aspectRatio
+
+    actual fun getPreviewScaleType(): PreviewScaleType = previewScaleType
 
     /**
      * Gets the current quality prioritization setting.

--- a/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/controller/DesktopCameraControllerBuilder.kt
+++ b/cameraK/src/desktopMain/kotlin/com/kashif/cameraK/controller/DesktopCameraControllerBuilder.kt
@@ -7,6 +7,7 @@ import com.kashif.cameraK.enums.CameraLens
 import com.kashif.cameraK.enums.Directory
 import com.kashif.cameraK.enums.FlashMode
 import com.kashif.cameraK.enums.ImageFormat
+import com.kashif.cameraK.enums.PreviewScaleType
 import com.kashif.cameraK.enums.QualityPrioritization
 import com.kashif.cameraK.enums.TorchMode
 import com.kashif.cameraK.utils.InvalidConfigurationException
@@ -27,6 +28,7 @@ class DesktopCameraControllerBuilder : CameraControllerBuilder {
     private var qualityPriority: QualityPrioritization = QualityPrioritization.NONE
     private var targetResolution: Pair<Int, Int>? = null
     private var aspectRatio: AspectRatio = AspectRatio.RATIO_16_9
+    private var previewScaleType: PreviewScaleType = PreviewScaleType.FIT_CENTER
 
     /**
      * Sets the frame grabber for camera input.
@@ -87,6 +89,11 @@ class DesktopCameraControllerBuilder : CameraControllerBuilder {
         return this
     }
 
+    override fun setPreviewScaleType(previewScaleType: PreviewScaleType): CameraControllerBuilder {
+        this.previewScaleType = previewScaleType
+        return this
+    }
+
     override fun setDirectory(directory: Directory): CameraControllerBuilder {
         this.directory = directory
         return this
@@ -103,6 +110,7 @@ class DesktopCameraControllerBuilder : CameraControllerBuilder {
             customGrabber = grabber,
             targetResolution = targetResolution,
             aspectRatio = aspectRatio,
+            previewScaleType = previewScaleType,
         )
     }
 }

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -81,6 +81,38 @@ config = CameraConfiguration(
 )
 ```
 
+## Preview Scale Type
+
+Control how the camera preview is scaled within its container view when the preview and container aspect ratios differ:
+
+```kotlin
+config = CameraConfiguration(
+    previewScaleType = PreviewScaleType.FILL_CENTER
+)
+```
+
+**Options:**
+
+| Scale Type | Behavior | Android | iOS |
+|------------|----------|---------|-----|
+| `FIT_CENTER` | Fit the whole frame, letterboxing overflow (default) | `PreviewView.ScaleType.FIT_CENTER` | `AVLayerVideoGravityResizeAspect` |
+| `FILL_CENTER` | Fill the container, cropping overflow | `PreviewView.ScaleType.FILL_CENTER` | `AVLayerVideoGravityResizeAspectFill` |
+
+**Example:**
+
+```kotlin
+// Edge-to-edge preview that crops to fill the container
+config = CameraConfiguration(
+    previewScaleType = PreviewScaleType.FILL_CENTER
+)
+```
+
+**Runtime query:**
+
+```kotlin
+val scaleType = controller.getPreviewScaleType()  // returns PreviewScaleType
+```
+
 ## Resolution
 
 Optionally set specific resolution:
@@ -236,6 +268,7 @@ fun ProfessionalCameraScreen() {
 
             // Image properties
             aspectRatio = AspectRatio.RATIO_4_3,
+            previewScaleType = PreviewScaleType.FILL_CENTER,
             targetResolution = 3840 to 2160,  // 4K
             imageFormat = ImageFormat.PNG,
 
@@ -351,6 +384,7 @@ controller.toggleCameraLens()  // BACK <-> FRONT
 | `cameraLens` | `CameraLens` | `BACK` | All |
 | `cameraDeviceType` | `CameraDeviceType` | `DEFAULT` | iOS only |
 | `aspectRatio` | `AspectRatio` | `RATIO_16_9` | All |
+| `previewScaleType` | `PreviewScaleType` | `FIT_CENTER` | All |
 | `targetResolution` | `Pair<Int, Int>` | Device default | All |
 | `flashMode` | `FlashMode` | `AUTO` | Android, iOS |
 | `imageFormat` | `ImageFormat` | `JPEG` | All |


### PR DESCRIPTION
## Summary

Expose a `PreviewScaleType` configuration (`FIT_CENTER` / `FILL_CENTER`) so callers can choose how
the camera preview is scaled within its container.

The iOS preview was hardcoded to letterbox (`AVLayerVideoGravityResizeAspect`), which produces
black bars whenever the view's aspect ratio differs from the camera output (e.g. a square 1:1
container over a 4:3 session preset). Android crops via `ViewPort.FILL_CENTER`, so the two
platforms rendered the same configuration differently.

## Changes

- Add `PreviewScaleType` enum (`commonMain/enums/PreviewScaleType.kt`).
- Add `previewScaleType: PreviewScaleType = PreviewScaleType.FIT_CENTER` to `CameraConfiguration`.
- Add `setPreviewScaleType(...)` to `CameraControllerBuilder` and implement it in the Android, iOS
  and Desktop builders.
- Add `getPreviewScaleType()` to the `CameraController` expect class and all actuals.
- Apply the setting:
  - Android: map to `PreviewView.ScaleType` in `CameraPreviewView`.
  - iOS: map to `AVCaptureVideoPreviewLayer.videoGravity` in `CustomCameraController.setupPreviewLayer`.

Mapping:

| `PreviewScaleType` | Android                      | iOS                                  |
|--------------------|------------------------------|--------------------------------------|
| `FIT_CENTER`       | `ScaleType.FIT_CENTER`       | `AVLayerVideoGravityResizeAspect`    |
| `FILL_CENTER`      | `ScaleType.FILL_CENTER`      | `AVLayerVideoGravityResizeAspectFill`|

`FIT_CENTER` is the default, preserving existing behavior.

## Motivation

Recurring request for apps that embed the preview in a non-native aspect-ratio layout (e.g. a
square QR scanner). Closes #163.

## Testing

- [X] Android: `FIT_CENTER` and `FILL_CENTER` render as expected.
- [X] iOS: `FIT_CENTER` and `FILL_CENTER` render as expected (no black bars with `FILL_CENTER`).
- [ ] Desktop: still builds and runs (preview scaling is a no-op there).

## Notes

- No public API break: every new parameter has a default value.
- The Desktop controller stores/reports the value for API consistency but does not apply it (the
  desktop capture path renders the webcam's native frame, same as `aspectRatio`).

Generated with Reasonix